### PR TITLE
feat: device error alerts on connect + firmware-gated UI features

### DIFF
--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -9,6 +9,8 @@ import { BottomNav, type TabId } from './components/BottomNav'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { ToastContainer } from './components/Toast'
 import { useSessionTracker } from './hooks/useSessionTracker'
+import { useDeviceAlerts } from './hooks/useDeviceAlerts'
+import { needsFactoryReset } from './ble/alerts'
 
 // Dynamic import — only loaded when VITE_DEV_SIMULATION is true.
 // Vite replaces the env check at build time → dead code elimination removes this entirely in production.
@@ -17,18 +19,32 @@ const SimulatorPanel =
     ? (await import('./components/SimulatorPanel')).SimulatorPanel
     : null
 
+function FactoryResetBanner() {
+  return (
+    <div class="bg-danger/15 border-danger/30 text-danger flex items-start gap-2 border-b px-4 py-2.5 text-xs font-semibold">
+      <span class="material-symbols-outlined text-[16px]">error</span>
+      <span>
+        The device reports an internal fault and requests a factory reset. Run Settings → Factory
+        Reset, or contact Storz & Bickel if the warning persists.
+      </span>
+    </div>
+  )
+}
+
 function AppContent() {
   const { state } = useCrafty()
   const [tab, setTab] = useState<TabId>('dashboard')
 
-  // Global tracker for sessions
+  // Global tracker for sessions + connect-time device error alerts
   useSessionTracker()
+  useDeviceAlerts()
 
   if (!state.connected) return <ConnectPage />
 
   return (
     <div class="flex h-full flex-col overflow-hidden">
       <TopBar />
+      {needsFactoryReset(state.projectRegRaw) && <FactoryResetBanner />}
       <div class="app-scroll min-h-0 flex-1 overflow-y-auto overscroll-y-contain">
         {tab === 'dashboard' && <MainPage />}
         {tab === 'history' && <HistoryPage />}

--- a/app/src/ble/CraftyConnection.ts
+++ b/app/src/ble/CraftyConnection.ts
@@ -41,6 +41,9 @@ export type CraftyState = {
   tempReached: boolean
   settingsRaw: number
   projectRegRaw: number
+  akkuStatus1: number
+  akkuStatus2: number
+  systemStatus: number
   deviceInfo: CraftyDeviceInfo | null
 }
 
@@ -103,6 +106,9 @@ export class CraftyConnection {
       tempReached: false,
       settingsRaw: 0,
       projectRegRaw: 0,
+      akkuStatus1: 0,
+      akkuStatus2: 0,
+      systemStatus: 0,
       deviceInfo: null,
     }
   }
@@ -318,7 +324,7 @@ export class CraftyConnection {
       bleFirmware: bleFw,
     }
 
-    // Control values
+    // Control values + status registers (for connect-time error alerts)
     const [setRaw, boostRaw, battRaw, ledRaw, autoOff, autoOffCur, chg, projReg, settReg] =
       await Promise.all([
         this.readU16(UUID.SET_TEMPERATURE),
@@ -331,6 +337,11 @@ export class CraftyConnection {
         this.readU16(UUID.PROJECT_REGISTER),
         this.readU16(UUID.SETTINGS_REGISTER_2),
       ])
+    const [akku1, akku2, sysStat] = await Promise.all([
+      this.readU16(UUID.AKKU_STATUS_1),
+      this.readU16(UUID.AKKU_STATUS_2),
+      this.readU16(UUID.SYSTEM_STATUS),
+    ])
 
     // Also read current temp
     const curRaw = await this.readU16(UUID.CURRENT_TEMPERATURE)
@@ -343,6 +354,9 @@ export class CraftyConnection {
     this.state.autoOffSeconds = autoOff
     this.state.autoOffRemaining = autoOffCur
     this.state.chargingStatus = chg
+    this.state.akkuStatus1 = akku1
+    this.state.akkuStatus2 = akku2
+    this.state.systemStatus = sysStat
     this.applyProjectRegister(projReg)
     this.applySettingsRegister(settReg)
     this.notify()

--- a/app/src/ble/alerts.ts
+++ b/app/src/ble/alerts.ts
@@ -1,0 +1,38 @@
+/**
+ * Device status-register evaluation, shared by the connect-time alert flow
+ * and the diagnostics view. Mirrors the official app's error checks.
+ */
+import { AKKU_1, AKKU_2, SYSTEM, PROJECT_REG } from './uuids'
+
+export type AlertSeverity = 'warning' | 'error'
+
+export interface DeviceAlert {
+  severity: AlertSeverity
+  message: string
+}
+
+export function evaluateStatusRegisters(
+  akkuStatus1: number,
+  akkuStatus2: number,
+  systemStatus: number,
+): DeviceAlert[] {
+  const alerts: DeviceAlert[] = []
+  if (akkuStatus1 & AKKU_1.BATTERY_LOW)
+    alerts.push({ severity: 'warning', message: 'Battery low – please charge' })
+  if (akkuStatus1 & AKKU_1.BATTERY_ERROR)
+    alerts.push({ severity: 'error', message: 'Battery error – contact Storz & Bickel' })
+  if (akkuStatus1 & AKKU_1.TEMP_WARNING)
+    alerts.push({ severity: 'warning', message: 'Battery temperature warning' })
+  if (akkuStatus1 & AKKU_1.COOL_DOWN)
+    alerts.push({ severity: 'error', message: 'Overheating – let the device cool down' })
+  if (akkuStatus2 & AKKU_2.CHARGER_ISSUE)
+    alerts.push({ severity: 'error', message: 'Charger issue – try a different cable' })
+  if (systemStatus & SYSTEM.ERROR)
+    alerts.push({ severity: 'error', message: 'System error – contact Storz & Bickel' })
+  return alerts
+}
+
+/** Device firmware flags that it wants a factory reset (persistent fault). */
+export function needsFactoryReset(projectReg: number): boolean {
+  return !!(projectReg & PROJECT_REG.FACTORY_RESET)
+}

--- a/app/src/components/Toast.tsx
+++ b/app/src/components/Toast.tsx
@@ -4,7 +4,7 @@
  */
 import { useState, useEffect, useCallback } from 'preact/hooks'
 
-type ToastType = 'error' | 'success' | 'info'
+type ToastType = 'error' | 'success' | 'info' | 'warning'
 type ToastItem = { id: number; message: string; type: ToastType }
 
 let nextId = 0
@@ -30,6 +30,7 @@ export const toast = {
   error: (msg: string) => add(msg, 'error'),
   success: (msg: string) => add(msg, 'success'),
   info: (msg: string) => add(msg, 'info'),
+  warning: (msg: string) => add(msg, 'warning', 6000),
 }
 
 export function ToastContainer() {
@@ -59,7 +60,9 @@ export function ToastContainer() {
               ? 'bg-danger text-white'
               : t.type === 'success'
                 ? 'bg-success text-white'
-                : 'bg-info text-white'
+                : t.type === 'warning'
+                  ? 'bg-warning text-black'
+                  : 'bg-info text-white'
           }`}
           onClick={() => dismiss(t.id)}
         >

--- a/app/src/hooks/useDeviceAlerts.ts
+++ b/app/src/hooks/useDeviceAlerts.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'preact/hooks'
+import { useCrafty } from './useCrafty'
+import { evaluateStatusRegisters } from '../ble/alerts'
+import { toast } from '../components/Toast'
+
+/**
+ * Surfaces device error flags (battery, overheat, charger, system) as toasts
+ * after connecting. Each alert fires once per connection; the set resets on
+ * disconnect so a reconnect re-checks the registers.
+ *
+ * The status registers arrive with the initial-state read shortly after
+ * `connected` flips true, so evaluation runs on every state change and
+ * dedupes via the shown-set instead of relying on timing.
+ */
+export function useDeviceAlerts(): void {
+  const { state } = useCrafty()
+  const shown = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    if (!state.connected) {
+      shown.current.clear()
+      return
+    }
+    for (const alert of evaluateStatusRegisters(
+      state.akkuStatus1,
+      state.akkuStatus2,
+      state.systemStatus,
+    )) {
+      if (shown.current.has(alert.message)) continue
+      shown.current.add(alert.message)
+      if (alert.severity === 'error') toast.error(alert.message)
+      else toast.warning(alert.message)
+    }
+  }, [state.connected, state.akkuStatus1, state.akkuStatus2, state.systemStatus])
+}

--- a/app/src/hooks/useDeviceCapabilities.ts
+++ b/app/src/hooks/useDeviceCapabilities.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'preact/hooks'
+import { useCrafty } from './useCrafty'
+import { isCraftyPlus, hasAdvancedFeatures } from '../ble/encoding'
+
+export interface DeviceCapabilities {
+  /** Auto-off timer is readable/writable (firmware ≥ V2.51) */
+  supportsAutoOff: boolean
+  /** Factory reset characteristic is available (firmware ≥ V2.51) */
+  supportsFactoryReset: boolean
+  /** Settings register (vibration, charge LED, permanent BLE) is writable (firmware ≥ V2.51) */
+  supportsBleSettings: boolean
+  /** Heater can be toggled over BLE (firmware ≥ V2.51) */
+  supportsHeaterControl: boolean
+  /** Find-device vibrate/blink (Crafty+ only) */
+  supportsFindDevice: boolean
+}
+
+/**
+ * Feature flags derived from the connected device's firmware version.
+ * Old firmware (< V2.51) silently ignores or rejects writes to these
+ * characteristics, so the UI hides the controls instead.
+ */
+export function useDeviceCapabilities(): DeviceCapabilities {
+  const { state } = useCrafty()
+  const fw = state.deviceInfo?.firmware ?? ''
+
+  return useMemo(() => {
+    const advanced = hasAdvancedFeatures(fw)
+    return {
+      supportsAutoOff: advanced,
+      supportsFactoryReset: advanced,
+      supportsBleSettings: advanced,
+      supportsHeaterControl: advanced,
+      supportsFindDevice: isCraftyPlus(fw),
+    }
+  }, [fw])
+}

--- a/app/src/hooks/useMainPageLogic.ts
+++ b/app/src/hooks/useMainPageLogic.ts
@@ -1,15 +1,14 @@
 import { useState, useCallback, useMemo } from 'preact/hooks'
 import { useCrafty } from './useCrafty'
+import { useDeviceCapabilities } from './useDeviceCapabilities'
 import { crafty } from '../ble'
 import { SUPERBOOST_OFFSET, TEMP_MAX } from '../ble/uuids'
-import { hasAdvancedFeatures } from '../ble/encoding'
 import { type Profile } from '../store/profiles'
 import { toast } from '../components/Toast'
 
 export function useMainPageLogic() {
   const { state } = useCrafty()
-  const fw = state.deviceInfo?.firmware ?? ''
-  const canHeaterControl = useMemo(() => hasAdvancedFeatures(fw), [fw])
+  const canHeaterControl = useDeviceCapabilities().supportsHeaterControl
 
   const [activeProfile, setActiveProfile] = useState<Profile | null>(null)
   const [pendingTemp, setPendingTemp] = useState<number | null>(null)

--- a/app/src/pages/SettingsPage.tsx
+++ b/app/src/pages/SettingsPage.tsx
@@ -5,8 +5,10 @@ import { toast } from '../components/Toast'
 import { useCrafty } from '../hooks/useCrafty'
 import { useSettings } from '../store/settings'
 import { useDeviceSettings } from '../hooks/useDeviceSettings'
+import { useDeviceCapabilities } from '../hooks/useDeviceCapabilities'
 import { crafty, type CraftyDiagnostics } from '../ble'
-import { AKKU_1, AKKU_2, SYSTEM } from '../ble/uuids'
+import { evaluateStatusRegisters } from '../ble/alerts'
+import { AKKU_1, SYSTEM } from '../ble/uuids'
 
 function SettingsCardToggle({
   icon,
@@ -64,6 +66,7 @@ function SettingsCardToggle({
 export function SettingsPage() {
   const { state, disconnect } = useCrafty()
   const isPlus = isCraftyPlus(state.deviceInfo?.firmware ?? '')
+  const caps = useDeviceCapabilities()
 
   const {
     setPendingLed,
@@ -178,15 +181,17 @@ export function SettingsPage() {
           onChange={toggleChargeLed}
         />
 
-        {/* Permanent Bluetooth */}
-        <SettingsCardToggle
-          icon="bluetooth"
-          label="Permanent BLE"
-          activeLabel="Always On"
-          inactiveLabel="Auto Sleep"
-          enabled={state.blePermanent}
-          onChange={toggleBlePermanent}
-        />
+        {/* Permanent Bluetooth (firmware ≥ V2.51) */}
+        {caps.supportsBleSettings && (
+          <SettingsCardToggle
+            icon="bluetooth"
+            label="Permanent BLE"
+            activeLabel="Always On"
+            inactiveLabel="Auto Sleep"
+            enabled={state.blePermanent}
+            onChange={toggleBlePermanent}
+          />
+        )}
       </section>
 
       {/* Sliders */}
@@ -203,19 +208,21 @@ export function SettingsPage() {
             onCommit={commitLed}
           />
         </div>
-        <div class="bg-surface-container-low space-y-4 rounded-2xl p-4 shadow-[0_4px_10px_rgba(0,0,0,0.5),inset_0_1px_1px_rgba(255,255,255,0.05)]">
-          <Slider
-            label="Auto-Off Timer"
-            displayValue={`${Math.floor(displayAutoOff / 60)}m ${displayAutoOff % 60}s`}
-            value={displayAutoOff}
-            min={10}
-            max={300}
-            step={5}
-            // ticks={['10s', '2m 30s', '5m']} // Omitting ticks to match the clean design
-            onChange={setPendingAutoOff}
-            onCommit={commitAutoOff}
-          />
-        </div>
+        {caps.supportsAutoOff && (
+          <div class="bg-surface-container-low space-y-4 rounded-2xl p-4 shadow-[0_4px_10px_rgba(0,0,0,0.5),inset_0_1px_1px_rgba(255,255,255,0.05)]">
+            <Slider
+              label="Auto-Off Timer"
+              displayValue={`${Math.floor(displayAutoOff / 60)}m ${displayAutoOff % 60}s`}
+              value={displayAutoOff}
+              min={10}
+              max={300}
+              step={5}
+              // ticks={['10s', '2m 30s', '5m']} // Omitting ticks to match the clean design
+              onChange={setPendingAutoOff}
+              onCommit={commitAutoOff}
+            />
+          </div>
+        )}
       </section>
 
       {/* Actions */}
@@ -228,7 +235,7 @@ export function SettingsPage() {
           <div class="h-px flex-1 bg-white/5"></div>
         </div>
 
-        {isPlus && (
+        {caps.supportsFindDevice && (
           <button
             type="button"
             onClick={() => crafty.findDevice().catch(() => toast.error('Find device failed'))}
@@ -276,28 +283,30 @@ export function SettingsPage() {
           </span>
         </button>
 
-        <button
-          type="button"
-          onClick={() => setShowFactoryReset((p) => !p)}
-          class="bg-surface-container-low group flex w-full items-center justify-between rounded-2xl p-4 shadow-[0_4px_10px_rgba(0,0,0,0.5),inset_0_1px_1px_rgba(255,255,255,0.05)] transition-all duration-300 hover:shadow-[0_4px_14px_rgba(244,67,54,0.3),inset_0_1px_1px_rgba(244,67,54,0.1)] active:scale-[0.98]"
-        >
-          <div class="flex items-center gap-4">
-            <div class="bg-danger/10 group-hover:bg-danger/20 flex h-10 w-10 items-center justify-center rounded-xl transition-colors">
-              <span class="material-symbols-outlined text-danger text-xl">factory</span>
+        {caps.supportsFactoryReset && (
+          <button
+            type="button"
+            onClick={() => setShowFactoryReset((p) => !p)}
+            class="bg-surface-container-low group flex w-full items-center justify-between rounded-2xl p-4 shadow-[0_4px_10px_rgba(0,0,0,0.5),inset_0_1px_1px_rgba(255,255,255,0.05)] transition-all duration-300 hover:shadow-[0_4px_14px_rgba(244,67,54,0.3),inset_0_1px_1px_rgba(244,67,54,0.1)] active:scale-[0.98]"
+          >
+            <div class="flex items-center gap-4">
+              <div class="bg-danger/10 group-hover:bg-danger/20 flex h-10 w-10 items-center justify-center rounded-xl transition-colors">
+                <span class="material-symbols-outlined text-danger text-xl">factory</span>
+              </div>
+              <div class="text-left">
+                <span class="font-label text-danger text-[10px] font-bold tracking-widest uppercase">
+                  Factory Reset
+                </span>
+                <p class="text-text-secondary/50 text-[10px]">Reset device settings to defaults</p>
+              </div>
             </div>
-            <div class="text-left">
-              <span class="font-label text-danger text-[10px] font-bold tracking-widest uppercase">
-                Factory Reset
-              </span>
-              <p class="text-text-secondary/50 text-[10px]">Reset device settings to defaults</p>
-            </div>
-          </div>
-          <span class="material-symbols-outlined text-text-secondary/30 group-hover:text-danger transition-colors">
-            chevron_right
-          </span>
-        </button>
+            <span class="material-symbols-outlined text-text-secondary/30 group-hover:text-danger transition-colors">
+              chevron_right
+            </span>
+          </button>
+        )}
 
-        {showFactoryReset && (
+        {caps.supportsFactoryReset && showFactoryReset && (
           <div class="bg-danger/5 space-y-3 rounded-2xl p-4 shadow-[0_4px_10px_rgba(244,67,54,0.1),inset_0_1px_1px_rgba(244,67,54,0.2)]">
             <p class="text-danger text-xs">All device settings will be reset. Are you sure?</p>
             <div class="flex gap-2">
@@ -437,14 +446,9 @@ function DiagnosticsSection({ state }: { state: ReturnType<typeof useCrafty>['st
 
 function buildWarnings(diag: CraftyDiagnostics | null): string[] {
   if (!diag) return []
-  const w: string[] = []
-  if (diag.akkuStatus1 & AKKU_1.BATTERY_LOW) w.push('Battery low – please charge')
-  if (diag.akkuStatus1 & AKKU_1.BATTERY_ERROR) w.push('Battery error – contact Storz & Bickel')
-  if (diag.akkuStatus1 & AKKU_1.TEMP_WARNING) w.push('Battery temperature warning')
-  if (diag.akkuStatus1 & AKKU_1.COOL_DOWN) w.push('Let the device cool down')
-  if (diag.akkuStatus2 & AKKU_2.CHARGER_ISSUE) w.push('Charger issue – use a different cable')
-  if (diag.systemStatus & SYSTEM.ERROR) w.push('System error – contact Storz & Bickel')
-  return w
+  return evaluateStatusRegisters(diag.akkuStatus1, diag.akkuStatus2, diag.systemStatus).map(
+    (a) => a.message,
+  )
 }
 
 function buildSections(


### PR DESCRIPTION
## Summary

Consolidated implementation of #9 and #10 ("device awareness" package). Re-opened from #22, which GitHub auto-closed when its stacked base branch (`fix/deep-audit`, #21) was deleted on merge — full description over there.

Closes #9, closes #10.

- `readInitialState` reads `AKKU_STATUS_1/2` + `SYSTEM_STATUS` into `CraftyState`
- `ble/alerts.ts`: shared status-register evaluation, also used by diagnostics warnings
- `useDeviceAlerts`: severity-coded toasts once per connection (new `toast.warning` type)
- Persistent factory-reset banner driven by `PROJECT_REGISTER & 0x8000`
- `useDeviceCapabilities()`: firmware-derived feature flags; Settings hides auto-off / factory reset / permanent BLE on firmware < V2.51, find-device stays Crafty+ only

## Verification
- `tsc -b`, `eslint`, `vite build` green
- GitNexus `detect_changes`: only intended symbols/flows affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)